### PR TITLE
Kullanıcı oturum yönetimi ve admin erişim hatalarını düzelt

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -71,10 +71,20 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 				Name:  "Admin User",
 			}
 
-			// Oturum oluştur
-			err := h.SessionManager.SetSession(w, r, "user", user)
-			if err != nil {
-				AuthLogger.Printf("Login - Oturum oluşturma hatası: %v", err)
+			// Oturum oluştur - kullanıcı bilgilerini ve yetki durumunu kaydet
+			if err := h.SessionManager.SetSession(w, r, UserKey, user); err != nil {
+				AuthLogger.Printf("Login - Oturum oluşturma hatası (user): %v", err)
+				h.RedirectWithFlash(w, r, "/login", "Oturum oluşturulurken hata oluştu")
+				return
+			}
+			// Kullanıcı kimliği ve admin bayrağını ekle
+			if err := h.SessionManager.SetSession(w, r, "user_id", user.ID); err != nil {
+				AuthLogger.Printf("Login - Oturum oluşturma hatası (user_id): %v", err)
+				h.RedirectWithFlash(w, r, "/login", "Oturum oluşturulurken hata oluştu")
+				return
+			}
+			if err := h.SessionManager.SetSession(w, r, "is_admin", true); err != nil {
+				AuthLogger.Printf("Login - Oturum oluşturma hatası (is_admin): %v", err)
 				h.RedirectWithFlash(w, r, "/login", "Oturum oluşturulurken hata oluştu")
 				return
 			}

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -13,12 +13,11 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-// contextKey, context değerleri için özel anahtar tipi
-type contextKey string
-
+// Sabitler - oturum ve context anahtarları
 const (
 	SessionCookieName = "kolaj-session"
-	UserKey           = contextKey("user")
+	// UserKey hem context aktarımında hem de oturum verilerinde kullanılacak
+	UserKey           = "user"
 	FlashKey          = "flash"
 )
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Unify user session key and set admin flags during login to prevent unauthorized admin access.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `UserKey` used for storing user objects in the session and for context propagation had a type mismatch, leading to inconsistent session retrieval. Additionally, the `user_id` and `is_admin` flags, crucial for the `IsAdmin` check, were not being set in the session upon successful admin login. These issues combined allowed unauthorized access to admin routes. This PR resolves these discrepancies by standardizing the `UserKey` and ensuring the necessary admin flags are correctly stored in the session.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac7caa8c-bb24-482c-a054-4e01a0bb171b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac7caa8c-bb24-482c-a054-4e01a0bb171b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>